### PR TITLE
Select random line from txt file instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,9 +112,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "log"
@@ -142,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +174,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -285,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,5 +447,6 @@ name = "wtc"
 version = "0.1.0"
 dependencies = [
  "exitcode",
+ "rand",
  "ureq",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 exitcode = "1.1.2"
 ureq = "2.4.0"
+rand = "0.8.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,23 @@
+use rand::seq::SliceRandom;
 use ureq::Error;
 
+const REMOTE_FILE: &str =
+    "https://raw.githubusercontent.com/ngerakines/commitment/master/commit_messages.txt";
+
+fn load_commit_file() -> Result<String, Error> {
+    // download file
+    let response = ureq::get(REMOTE_FILE).call()?;
+    let content = response.into_string()?;
+    // TODO: save file to temp dir:
+    // const TEMP_FILE: &str = "/tmp/commit_messages.txt";
+    // return content
+    Ok(content)
+}
+
 fn main() {
-    match ureq::get("http://whatthecommit.com/index.txt").call() {
-        Ok(response) => {
-            println!("{}", response.into_string().unwrap().trim());
-        }
-        Err(Error::Status(code, _)) => {
-            println!("ERROR: HTTP {}", code);
-            std::process::exit(exitcode::DATAERR);
-        }
-        Err(_) => {
-            /* some kind of io/transport error */
-            println!("IO transport error!");
-            std::process::exit(exitcode::DATAERR);
-        }
-    }
+    let content = load_commit_file().unwrap();
+    let lines: Vec<&str> = content.split('\n').collect();
+    let random_line = lines.choose(&mut rand::thread_rng()).unwrap();
+
+    println!("{}", random_line);
 }


### PR DESCRIPTION
Modified 'logic' to pull the whole list of WTCs and select random line instead of relying on whatthecommit.com/index.txt. It's faster.